### PR TITLE
Don't assume the location of guile

### DIFF
--- a/bin/kak-rainbow.scm
+++ b/bin/kak-rainbow.scm
@@ -1,4 +1,4 @@
-#!/usr/bin/guile -s
+#!/usr/bin/env -S guile -s
 !#
 
 (use-modules (ice-9 rdelim))


### PR DESCRIPTION
Previously, the script always assumed that it was in /usr/bin, which
it isn't on some systems (notably NixOS). This fixes that by using /usr/bin/env,
and passing the `-s` option to guile by passing the `-S` option to `env`.

Fixes #1